### PR TITLE
Configure cmake to use riscv-none-embed-objcopy

### DIFF
--- a/toolchain-rv32.cmake
+++ b/toolchain-rv32.cmake
@@ -3,6 +3,7 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_C_COMPILER riscv-none-embed-gcc)
 set(CMAKE_CXX_COMPILER riscv-none-embed-g++)
 set(CMAKE_ASM_COMPILER riscv-none-embed-gcc)
+set(CMAKE_OBJCOPY riscv-none-embed-objcopy)
 
 set(CMAKE_C_FLAGS "-march=rv32imc" CACHE STRING "C Compiler Base Flags")
 set(CMAKE_CXX_FLAGS "-march=rv32imc" CACHE STRING "C++ Compiler Base Flags")


### PR DESCRIPTION
The default objcopy found by cmake may not support riscv32.